### PR TITLE
Fix directory page scroll reset and add sorting/filter loading states

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,6 +60,7 @@ All runtime DB reads/writes go through server actions in `src/app/actions/data.t
 
 - Feature branches are cut from `dev`, named `feature/<issue-number>-short-description`
 - PRs merge into `dev`; `master` is updated periodically in bulk
+- Always apply a label when creating issues via `gh issue create --label <label>`; available labels: `bug`, `enhancement`, `documentation`, `duplicate`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`
 
 # Testing
 

--- a/src/app/directory/FilterCard.tsx
+++ b/src/app/directory/FilterCard.tsx
@@ -36,6 +36,7 @@ export default function FilterCard({ cities }: { cities: string[] }) {
     const [cityInput, setCityInput] = useState(searchParams.get("city") || "");
     const [showCitySuggestions, setShowCitySuggestions] = useState(false);
     const [isApplying, setIsApplying] = useState(false);
+    const [isResetting, setIsResetting] = useState(false);
 
     const citySuggestions = cityInput
         ? cities
@@ -61,6 +62,7 @@ export default function FilterCard({ cities }: { cities: string[] }) {
             itemsPerPage: searchParams.get("itemsPerPage") || "",
         });
         setIsApplying(false);
+        setIsResetting(false);
     }, [searchParams]);
 
     function handleFilterSubmit(data: FormData) {
@@ -199,7 +201,10 @@ export default function FilterCard({ cities }: { cities: string[] }) {
                         name="Reset Filters"
                         variant="secondary"
                         type="reset"
+                        loading={isResetting}
+                        loadingText="Resetting"
                         onClick={() => {
+                            setIsResetting(true);
                             setActiveFilters({
                                 name: "",
                                 city: "",

--- a/src/app/directory/SortingBar.tsx
+++ b/src/app/directory/SortingBar.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import Form from "next/form";
 import { useRouter, useSearchParams } from "next/navigation";
 
 import Card from "@/components/Card";
-import { useEffect, useState } from "react";
-import { defaultSortBy } from "@/utils/defines";
+import { defaultSortBy, defaultItemsPerPage } from "@/utils/defines";
 
 type SortingBarProps = {
     page: number;
@@ -17,13 +15,8 @@ export default function SortingBar(props: SortingBarProps) {
     const router = useRouter();
     const searchParams = useSearchParams();
 
-    const [sortBy, setSortBy] = useState(
-        searchParams.get("sortBy") || defaultSortBy,
-    );
-
-    const [itemsPerPage, setItemsPerPage] = useState(
-        Number(searchParams.get("itemsPerPage")) || props.itemsPerPage,
-    );
+    const sortBy = searchParams.get("sortBy") || defaultSortBy;
+    const itemsPerPage = Number(searchParams.get("itemsPerPage")) || props.itemsPerPage;
 
     /* Calculate start and end item indices in the page */
     const displayStart = (props.page - 1) * props.itemsPerPage + 1;
@@ -33,24 +26,17 @@ export default function SortingBar(props: SortingBarProps) {
     );
     const numPages = Math.ceil(props.totalCount / props.itemsPerPage);
 
-    useEffect(() => {
+    function navigate(newSortBy: string, newItemsPerPage: number) {
         const params = new URLSearchParams(searchParams);
-        const currentPage = searchParams.get("page") || "1";
         const currentSortBy = searchParams.get("sortBy") || defaultSortBy;
-        const newPage = currentSortBy === sortBy ? currentPage : "1";
+        const currentPage = searchParams.get("page") || "1";
+        const newPage = currentSortBy === newSortBy ? currentPage : "1";
 
-        params.set("sortBy", sortBy);
+        params.set("sortBy", newSortBy);
         params.set("page", newPage);
-        params.set("itemsPerPage", String(itemsPerPage));
+        params.set("itemsPerPage", String(newItemsPerPage));
         router.push(`/directory/?${params.toString()}`);
-    }, [sortBy, itemsPerPage]);
-
-    useEffect(() => {
-        setSortBy(searchParams.get("sortBy") || defaultSortBy);
-        setItemsPerPage(
-            Number(searchParams.get("itemsPerPage")) || props.itemsPerPage,
-        );
-    }, [searchParams]);
+    }
 
     return (
         <Card>
@@ -65,36 +51,29 @@ export default function SortingBar(props: SortingBarProps) {
                     <span>{`${props.totalCount == 1 ? "facility" : "facilities"}`}</span>
                 </div>
                 <div>
-                    <Form action={() => {}}>
-                        <div className="flex items-center gap-5 text-sm">
-                            <label htmlFor="sortBy">Sort By</label>
-                            <select
-                                name="sortBy"
-                                value={sortBy}
-                                onChange={(e) => {
-                                    setSortBy(e.target.value);
-                                }}
-                            >
-                                <option value="name">Name</option>
-                                <option value="city">City</option>
-                            </select>
-                            <label htmlFor="itemsPerPage">Items Per Page</label>
-                            <select
-                                name="itemsPerPage"
-                                value={itemsPerPage}
-                                onChange={(e) => {
-                                    const val = Number(e.target.value);
-                                    setItemsPerPage(val);
-                                }}
-                            >
-                                {[5, 10, 20, 50].map((n) => (
-                                    <option key={n} value={n}>
-                                        {n}
-                                    </option>
-                                ))}
-                            </select>
-                        </div>
-                    </Form>
+                    <div className="flex items-center gap-5 text-sm">
+                        <label htmlFor="sortBy">Sort By</label>
+                        <select
+                            name="sortBy"
+                            value={sortBy}
+                            onChange={(e) => navigate(e.target.value, itemsPerPage)}
+                        >
+                            <option value="name">Name</option>
+                            <option value="city">City</option>
+                        </select>
+                        <label htmlFor="itemsPerPage">Items Per Page</label>
+                        <select
+                            name="itemsPerPage"
+                            value={itemsPerPage}
+                            onChange={(e) => navigate(sortBy, Number(e.target.value))}
+                        >
+                            {[5, 10, 20, 50].map((n) => (
+                                <option key={n} value={n}>
+                                    {n}
+                                </option>
+                            ))}
+                        </select>
+                    </div>
                 </div>
             </div>
         </Card>

--- a/src/app/directory/SortingBar.tsx
+++ b/src/app/directory/SortingBar.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useTransition } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import { Loader } from "lucide-react";
 
 import Card from "@/components/Card";
 import { defaultSortBy, defaultItemsPerPage } from "@/utils/defines";
@@ -14,6 +16,7 @@ type SortingBarProps = {
 export default function SortingBar(props: SortingBarProps) {
     const router = useRouter();
     const searchParams = useSearchParams();
+    const [isPending, startTransition] = useTransition();
 
     const sortBy = searchParams.get("sortBy") || defaultSortBy;
     const itemsPerPage = Number(searchParams.get("itemsPerPage")) || props.itemsPerPage;
@@ -35,7 +38,9 @@ export default function SortingBar(props: SortingBarProps) {
         params.set("sortBy", newSortBy);
         params.set("page", newPage);
         params.set("itemsPerPage", String(newItemsPerPage));
-        router.push(`/directory/?${params.toString()}`);
+        startTransition(() => {
+            router.push(`/directory/?${params.toString()}`);
+        });
     }
 
     return (
@@ -52,10 +57,14 @@ export default function SortingBar(props: SortingBarProps) {
                 </div>
                 <div>
                     <div className="flex items-center gap-5 text-sm">
+                        {isPending && (
+                            <Loader className="h-4 w-4 animate-spin text-gray-400" />
+                        )}
                         <label htmlFor="sortBy">Sort By</label>
                         <select
                             name="sortBy"
                             value={sortBy}
+                            disabled={isPending}
                             onChange={(e) => navigate(e.target.value, itemsPerPage)}
                         >
                             <option value="name">Name</option>
@@ -65,6 +74,7 @@ export default function SortingBar(props: SortingBarProps) {
                         <select
                             name="itemsPerPage"
                             value={itemsPerPage}
+                            disabled={isPending}
                             onChange={(e) => navigate(sortBy, Number(e.target.value))}
                         >
                             {[5, 10, 20, 50].map((n) => (


### PR DESCRIPTION
Closes #27

## Summary

- Fix scroll-to-top on directory page load caused by `SortingBar`'s `useEffect` firing on mount and calling `router.push`
- Replace the effect with direct `router.push` calls in `onChange` handlers; read sort state from `searchParams` instead of mirroring in `useState`
- Wrap `router.push` in `useTransition` to show a spinner and disable selects while results load
- Add loading state to FilterCard's Reset button (`isResetting` / "Resetting"), mirroring the existing Apply button behaviour

## Test plan

- [ ] Open `/directory`, scroll down — page should no longer jump back to the top
- [ ] Change Sort By or Items Per Page — spinner should appear and selects should be disabled until results update
- [ ] Apply filters then click Reset — Reset button should show "Resetting" while navigating

🤖 Generated with [Claude Code](https://claude.com/claude-code)