### PR TITLE
Fix directory filter reset not updating list and button stuck in loading

### DIFF
--- a/src/app/directory/FilterCard.tsx
+++ b/src/app/directory/FilterCard.tsx
@@ -40,9 +40,7 @@ export default function FilterCard({ cities }: { cities: string[] }) {
 
     const citySuggestions = cityInput
         ? cities
-              .filter((c) =>
-                  c.toLowerCase().includes(cityInput.toLowerCase()),
-              )
+              .filter((c) => c.toLowerCase().includes(cityInput.toLowerCase()))
               .slice(0, 8)
         : [];
 
@@ -65,6 +63,30 @@ export default function FilterCard({ cities }: { cities: string[] }) {
         setIsResetting(false);
     }, [searchParams]);
 
+    function handleFilterReset() {
+        const hasActiveFilters =
+            activeFilters.name ||
+            activeFilters.city ||
+            activeFilters.managedBy ||
+            activeFilters.district ||
+            activeFilters.province;
+
+        if (hasActiveFilters) {
+            setIsResetting(true);
+        }
+
+        setActiveFilters({
+            name: "",
+            city: "",
+            managedBy: "",
+            district: "",
+            province: "",
+        });
+
+        setCityInput("");
+        router.push("/directory");
+    }
+
     function handleFilterSubmit(data: FormData) {
         const params = new URLSearchParams();
         params.set("name", data.get("name")?.toString() || "");
@@ -83,9 +105,6 @@ export default function FilterCard({ cities }: { cities: string[] }) {
             <h1 className="pb-5 text-xl font-semibold">Filters</h1>
             <Form
                 action={handleFilterSubmit}
-                onReset={() => {
-                    router.push("/directory");
-                }}
                 onSubmit={() => setIsApplying(true)}
                 className="flex flex-col gap-5 py-3"
             >
@@ -95,7 +114,13 @@ export default function FilterCard({ cities }: { cities: string[] }) {
                         id="name"
                         name="name"
                         type="text"
-                        defaultValue={activeFilters.name}
+                        value={activeFilters.name}
+                        onChange={(e) =>
+                            setActiveFilters({
+                                ...activeFilters,
+                                name: e.target.value,
+                            })
+                        }
                     ></input>
                 </div>
                 <div className="relative flex flex-col gap-2">
@@ -111,7 +136,10 @@ export default function FilterCard({ cities }: { cities: string[] }) {
                         onBlur={() => setShowCitySuggestions(false)}
                     />
                     {showCitySuggestions && citySuggestions.length > 0 && (
-                        <ul id="city-suggestions" className="absolute top-full z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md">
+                        <ul
+                            id="city-suggestions"
+                            className="absolute top-full z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md"
+                        >
                             {citySuggestions.map((city) => (
                                 <li
                                     key={city}
@@ -134,7 +162,13 @@ export default function FilterCard({ cities }: { cities: string[] }) {
                         id="managedBy"
                         name="managedBy"
                         type="text"
-                        defaultValue={activeFilters.managedBy}
+                        value={activeFilters.managedBy}
+                        onChange={(e) =>
+                            setActiveFilters({
+                                ...activeFilters,
+                                managedBy: e.target.value,
+                            })
+                        }
                     ></input>
                 </div>
                 <div className="flex flex-col gap-2">
@@ -200,20 +234,10 @@ export default function FilterCard({ cities }: { cities: string[] }) {
                     <Button
                         name="Reset Filters"
                         variant="secondary"
-                        type="reset"
+                        type="button"
                         loading={isResetting}
                         loadingText="Resetting"
-                        onClick={() => {
-                            setIsResetting(true);
-                            setActiveFilters({
-                                name: "",
-                                city: "",
-                                managedBy: "",
-                                district: "",
-                                province: "",
-                            });
-                            setCityInput("");
-                        }}
+                        onClick={handleFilterReset}
                     >
                         Reset
                     </Button>

--- a/tests/e2e/directory-filter-reset.spec.ts
+++ b/tests/e2e/directory-filter-reset.spec.ts
@@ -1,0 +1,232 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Directory filter - Name field", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/directory");
+    });
+
+    test("applying name filter updates URL", async ({ page }) => {
+        await page.getByLabel("Name").fill("Sevana");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/name=Sevana/);
+    });
+
+    test("name filter value is restored when navigating to a filtered URL", async ({
+        page,
+    }) => {
+        await page.goto("/directory?name=Sevana");
+        await expect(page.getByLabel("Name")).toHaveValue("Sevana");
+    });
+
+    test("reset clears name field", async ({ page }) => {
+        await page.getByLabel("Name").fill("Sevana");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/name=Sevana/);
+
+        await page.getByRole("button", { name: "Reset" }).click();
+        await expect(page.getByLabel("Name")).toHaveValue("");
+    });
+});
+
+test.describe("Directory filter - City field", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/directory");
+    });
+
+    test("applying city filter updates URL", async ({ page }) => {
+        await page.getByLabel("City").fill("Kandy");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/city=Kandy/);
+    });
+
+    test("city filter value is restored when navigating to a filtered URL", async ({
+        page,
+    }) => {
+        await page.goto("/directory?city=Kandy");
+        await expect(page.getByLabel("City")).toHaveValue("Kandy");
+    });
+
+    test("reset clears city field", async ({ page }) => {
+        await page.getByLabel("City").fill("Kandy");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/city=Kandy/);
+
+        await page.getByRole("button", { name: "Reset" }).click();
+        await expect(page.getByLabel("City")).toHaveValue("");
+    });
+});
+
+test.describe("Directory filter - Managed By field", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/directory");
+    });
+
+    test("applying managed by filter updates URL", async ({ page }) => {
+        await page.getByLabel("Managed By").fill("Government");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/managedBy=Government/);
+    });
+
+    test("managed by filter value is restored when navigating to a filtered URL", async ({
+        page,
+    }) => {
+        await page.goto("/directory?managedBy=Government");
+        await expect(page.getByLabel("Managed By")).toHaveValue("Government");
+    });
+
+    test("reset clears managed by field", async ({ page }) => {
+        await page.getByLabel("Managed By").fill("Government");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/managedBy=Government/);
+
+        await page.getByRole("button", { name: "Reset" }).click();
+        await expect(page.getByLabel("Managed By")).toHaveValue("");
+    });
+});
+
+test.describe("Directory filter - Province field", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/directory");
+    });
+
+    test("applying province filter updates URL", async ({ page }) => {
+        await page.getByLabel("Province").selectOption("Central");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/province=Central/);
+    });
+
+    test("province filter value is restored when navigating to a filtered URL", async ({
+        page,
+    }) => {
+        await page.goto("/directory?province=Central");
+        await expect(page.getByLabel("Province")).toHaveValue("Central");
+    });
+
+    test("selecting a province enables the district dropdown", async ({
+        page,
+    }) => {
+        await expect(page.getByLabel("District")).toBeDisabled();
+        await page.getByLabel("Province").selectOption("Central");
+        await expect(page.getByLabel("District")).toBeEnabled();
+    });
+
+    test("district dropdown shows only districts for the selected province", async ({
+        page,
+    }) => {
+        await page.getByLabel("Province").selectOption("Central");
+        const districtSelect = page.getByLabel("District");
+        await expect(districtSelect.locator("option", { hasText: "Kandy" })).toBeAttached();
+        await expect(districtSelect.locator("option", { hasText: "Colombo" })).not.toBeAttached();
+    });
+
+    test("reset clears province field", async ({ page }) => {
+        await page.getByLabel("Province").selectOption("Central");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/province=Central/);
+
+        await page.getByRole("button", { name: "Reset" }).click();
+        await expect(page.getByLabel("Province")).toHaveValue("");
+    });
+});
+
+test.describe("Directory filter - District field", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/directory");
+    });
+
+    test("district dropdown is disabled when no province is selected", async ({
+        page,
+    }) => {
+        await expect(page.getByLabel("District")).toBeDisabled();
+    });
+
+    test("applying district filter updates URL with province and district", async ({
+        page,
+    }) => {
+        await page.getByLabel("Province").selectOption("Central");
+        await page.getByLabel("District").selectOption("Kandy");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/province=Central/);
+        await expect(page).toHaveURL(/district=Kandy/);
+    });
+
+    test("district filter values are restored when navigating to a filtered URL", async ({
+        page,
+    }) => {
+        await page.goto("/directory?province=Central&district=Kandy");
+        await expect(page.getByLabel("Province")).toHaveValue("Central");
+        await expect(page.getByLabel("District")).toHaveValue("Kandy");
+    });
+
+    test("reset clears district field", async ({ page }) => {
+        await page.getByLabel("Province").selectOption("Central");
+        await page.getByLabel("District").selectOption("Kandy");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/district=Kandy/);
+
+        await page.getByRole("button", { name: "Reset" }).click();
+        await expect(page.getByLabel("District")).toBeDisabled();
+    });
+});
+
+test.describe("Directory filter reset", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("/directory");
+    });
+
+    test("reset clears all filter fields", async ({ page }) => {
+        await page.getByLabel("Name").fill("Sevana");
+        await page.getByLabel("City").fill("Kandy");
+        await page.getByLabel("Managed By").fill("Government");
+        await page.getByLabel("Province").selectOption("Central");
+
+        await page.getByRole("button", { name: "Reset" }).click();
+
+        await expect(page.getByLabel("Name")).toHaveValue("");
+        await expect(page.getByLabel("City")).toHaveValue("");
+        await expect(page.getByLabel("Managed By")).toHaveValue("");
+        await expect(page.getByLabel("Province")).toHaveValue("");
+    });
+
+    test("reset navigates to /directory with no filter params", async ({
+        page,
+    }) => {
+        await page.getByLabel("Province").selectOption("Western");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/province=Western/);
+
+        await page.getByRole("button", { name: "Reset" }).click();
+        await expect(page).toHaveURL(/\/directory\/?(\?.*)?$/, {
+            timeout: 5000,
+        });
+        await expect(page).not.toHaveURL(/province=/);
+    });
+
+    test("reset button does not stay in loading state after resetting", async ({
+        page,
+    }) => {
+        await page.getByLabel("Province").selectOption("Western");
+        await page.getByRole("button", { name: "Apply" }).click();
+        await expect(page).toHaveURL(/province=Western/);
+
+        await page.getByRole("button", { name: "Reset" }).click();
+
+        await expect(
+            page.getByRole("button", { name: "Resetting" }),
+        ).not.toBeVisible({ timeout: 5000 });
+        await expect(page.getByRole("button", { name: "Reset" })).toBeEnabled({
+            timeout: 5000,
+        });
+    });
+
+    test("reset with no active filters does not show loading state", async ({
+        page,
+    }) => {
+        await page.getByRole("button", { name: "Reset" }).click();
+
+        await expect(
+            page.getByRole("button", { name: "Resetting" }),
+        ).not.toBeVisible();
+        await expect(page.getByRole("button", { name: "Reset" })).toBeEnabled();
+    });
+});


### PR DESCRIPTION
Fixes #31

## Summary

- `next/form` doesn't reliably forward `onReset`, so `router.push("/directory")` was never called on reset — the list stayed filtered and the URL never changed
- `name` and `managedBy` inputs used `defaultValue` (uncontrolled), so clearing `activeFilters` had no effect on the DOM
- `isResetting` was set to `true` but only cleared when `searchParams` changed; since the URL never changed, the button was stuck in loading indefinitely

## Changes

- Made `name` and `managedBy` inputs controlled (`value` + `onChange`)
- Replaced `type="reset"` + `onReset` with a `handleFilterReset` function that calls `router.push` directly
- Guard: only set `isResetting=true` when there are active filters, preventing the deadlock when already at `/directory` with no params
- Added 22 Playwright e2e tests — per-field tests for Name, City, Managed By, Province, and District, plus reset behaviour tests

## Test plan

- [ ] Apply a filter and click Reset — list updates, URL clears
- [ ] Reset button returns to normal state (not stuck on "Resetting")
- [ ] Clicking Reset with no active filters — button doesn't enter loading state
- [ ] All 22 new e2e tests pass (`npx playwright test tests/e2e/directory-filter-reset.spec.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)