### PR TITLE
Show full city list on focus and make dropdown scrollable

### DIFF
--- a/src/app/directory/FilterCard.tsx
+++ b/src/app/directory/FilterCard.tsx
@@ -39,10 +39,10 @@ export default function FilterCard({ cities }: { cities: string[] }) {
     const [isResetting, setIsResetting] = useState(false);
 
     const citySuggestions = cityInput
-        ? cities
-              .filter((c) => c.toLowerCase().includes(cityInput.toLowerCase()))
-              .slice(0, 8)
-        : [];
+        ? cities.filter((c) =>
+              c.toLowerCase().includes(cityInput.toLowerCase()),
+          )
+        : cities;
 
     useEffect(() => {
         const city = searchParams.get("city") || "";
@@ -138,7 +138,7 @@ export default function FilterCard({ cities }: { cities: string[] }) {
                     {showCitySuggestions && citySuggestions.length > 0 && (
                         <ul
                             id="city-suggestions"
-                            className="absolute top-full z-10 mt-1 w-full overflow-hidden rounded-lg border border-gray-300 bg-white shadow-md"
+                            className="absolute top-full z-10 mt-1 max-h-48 w-full overflow-y-auto rounded-lg border border-gray-300 bg-white shadow-md"
                         >
                             {citySuggestions.map((city) => (
                                 <li

--- a/tests/e2e/city-autocomplete.spec.ts
+++ b/tests/e2e/city-autocomplete.spec.ts
@@ -5,6 +5,13 @@ test.describe("City autocomplete in directory filter", () => {
         await page.goto("/directory");
     });
 
+    test("suggestions appear on focus without typing", async ({ page }) => {
+        const cityInput = page.getByLabel("City");
+        await cityInput.click();
+        const suggestions = page.locator("#city-suggestions li");
+        await expect(suggestions.first()).toBeVisible({ timeout: 5000 });
+    });
+
     test("suggestions appear when typing in the city field", async ({
         page,
     }) => {


### PR DESCRIPTION
Fixes #33

## Summary

- Focusing the city input now shows the complete list of cities immediately (previously nothing appeared until the user started typing)
- The suggestion dropdown is capped at `max-h-48` and scrollable, so it doesn't take over the screen
- Typing still filters the list in real time
- Removed the old 8-item cap (`.slice(0, 8)`) — unnecessary now that the list scrolls

## Test plan

- [x] Click the City field with no text — full city list appears
- [x] Scroll through the list
- [x] Type a partial city name — list filters in real time
- [x] Select a city — input populates and dropdown closes
- [x] All 4 city autocomplete e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)